### PR TITLE
Updates for 'Package.swift'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version:5.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -7,18 +6,12 @@ let package = Package(
     name: "NWWebSocket",
     platforms: [.iOS("13.0"), .macOS("10.15"), .tvOS("13.0")],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "NWWebSocket",
             targets: ["NWWebSocket"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "NWWebSocket",
             dependencies: []),


### PR DESCRIPTION
This PR makes some updates to `Package.swift`:

- Reduces the `swift-tools-version` to 5.0 from 5.3 for wider compatibility.
  - Also changes supported platforms to string literals from enum cases due to this change.
- Removes some redundant autogenerated comments.