### PR TITLE
Add watchOS support

### DIFF
--- a/NWWebSocket.podspec
+++ b/NWWebSocket.podspec
@@ -8,11 +8,12 @@ Pod::Spec.new do |s|
     s.source           = { git: "https://github.com/pusher/NWWebSocket.git", tag: s.version.to_s }
     s.social_media_url = 'https://twitter.com/pusher'
 
-    s.swift_version = '5.0'
+    s.swift_version = '5.1'
     s.requires_arc  = true
     s.source_files  = ['Sources/**/*.swift']
 
     s.ios.deployment_target = '13.0'
     s.osx.deployment_target = '10.15'
     s.tvos.deployment_target = '13.0'
+    s.watchos.deployment_target = '6.0'
 end

--- a/NWWebSocket.xcodeproj/project.pbxproj
+++ b/NWWebSocket.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
             SWIFT_VERSION = "5.0";
             TARGET_NAME = "NWWebSocket";
             TVOS_DEPLOYMENT_TARGET = "13.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+            WATCHOS_DEPLOYMENT_TARGET = "6.0";
          };
          name = "Debug";
       };
@@ -334,7 +334,7 @@
             SWIFT_VERSION = "5.0";
             TARGET_NAME = "NWWebSocket";
             TVOS_DEPLOYMENT_TARGET = "13.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+            WATCHOS_DEPLOYMENT_TARGET = "6.0";
          };
          name = "Release";
       };
@@ -379,7 +379,7 @@
                "-sdk",
                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
                "-package-description-version",
-               "5.0.0"
+               "5.1.0"
             );
             SWIFT_VERSION = "5.0";
          };
@@ -397,7 +397,7 @@
                "-sdk",
                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
                "-package-description-version",
-               "5.0.0"
+               "5.1.0"
             );
             SWIFT_VERSION = "5.0";
          };
@@ -520,7 +520,7 @@
             SWIFT_VERSION = "5.0";
             TARGET_NAME = "NWWebSocketTests";
             TVOS_DEPLOYMENT_TARGET = "13.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+            WATCHOS_DEPLOYMENT_TARGET = "6.0";
          };
          name = "Debug";
       };
@@ -574,7 +574,7 @@
             SWIFT_VERSION = "5.0";
             TARGET_NAME = "NWWebSocketTests";
             TVOS_DEPLOYMENT_TARGET = "13.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+            WATCHOS_DEPLOYMENT_TARGET = "6.0";
          };
          name = "Release";
       };

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,10 @@ import PackageDescription
 
 let package = Package(
     name: "NWWebSocket",
-    platforms: [.iOS("13.0"), .macOS("10.15"), .tvOS("13.0")],
+    platforms: [.iOS("13.0"),
+                .macOS("10.15"),
+                .tvOS("13.0"),
+                .watchOS("6.0")],
     products: [
         .library(
             name: "NWWebSocket",

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@
 A WebSocket client written in Swift, using the Network framework from Apple.
 
 ## Supported platforms
-- Swift 5.0 and above
+- Swift 5.1 and above
 - Xcode 11.0 and above
 
 ### Deployment targets
 - iOS 13.0 and above
 - macOS 10.15 and above
 - tvOS 13.0 and above
+- watchOS 6.0 and above
 
 ## Communication
 - If you have found a bug or have a feature request, please open an issue


### PR DESCRIPTION
This PR resolves #13:

- Specifies watchOS support for version 6.0 and above in `Package.swift`.
  - Also updates the `NWWebSocket.podspec` file.
- Upgrades the `swift-tools-version` from 5.0 to 5.1.
  - This is needed because iOS 13, tvOS and watchOS 6 SDKs all shipped with Swift 5.1 in Xcode 11.0.
- Updates the README.