### PR TITLE
Recreating connection instead of calling start again (it's not allowed)

### DIFF
--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -60,9 +60,10 @@ open class NWWebSocket: WebSocketConnection {
     // MARK: - WebSocketConnection conformance
 
     open func connect() {
-        if connection == nil {
-            connection = NWConnection(to: endpoint, using: parameters)
-        }
+        connection?.stateUpdateHandler = nil
+        connection?.cancel()
+        
+        connection = NWConnection(to: endpoint, using: parameters)
         intentionalDisconnect = false
         connection?.stateUpdateHandler = stateDidChange(to:)
         listen()


### PR DESCRIPTION
As per documentation a connection should only receiver a start call once.