### PR TITLE
Error reporting improvements

### DIFF
--- a/Sources/NWWebSocket/Protocol/WebSocketConnection.swift
+++ b/Sources/NWWebSocket/Protocol/WebSocketConnection.swift
@@ -51,9 +51,9 @@ public protocol WebSocketConnectionDelegate: AnyObject {
     /// An error received by a WebSocket is not necessarily fatal.
     /// - Parameters:
     ///   - connection: The `WebSocketConnection` that received an error.
-    ///   - error: The `Error` that was received.
+    ///   - error: The `NWError` that was received.
     func webSocketDidReceiveError(connection: WebSocketConnection,
-                                  error: Error)
+                                  error: NWError)
 
     /// Tells the delegate that the WebSocket received a 'pong' from the server.
     /// - Parameter connection: The active `WebSocketConnection`.

--- a/Tests/NWWebSocketTests/NWWebSocketTests.swift
+++ b/Tests/NWWebSocketTests/NWWebSocketTests.swift
@@ -135,7 +135,7 @@ extension NWWebSocketTests: WebSocketConnectionDelegate {
         Self.disconnectExpectation.fulfill()
     }
 
-    func webSocketDidReceiveError(connection: WebSocketConnection, error: Error) {
+    func webSocketDidReceiveError(connection: WebSocketConnection, error: NWError) {
         Self.errorExpectation?.fulfill()
     }
 


### PR DESCRIPTION
This PR:

- Improves error reporting by passing the `NWError` when calling `webSocketDidReceiveError(…)`