### PR TITLE
Connection state change handling improvements

### DIFF
--- a/NWWebSocket.xcodeproj/project.pbxproj
+++ b/NWWebSocket.xcodeproj/project.pbxproj
@@ -5,10 +5,10 @@
    objects = {
       "NWWebSocket::NWWebSocket" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_29";
+         buildConfigurationList = "OBJ_31";
          buildPhases = (
-            "OBJ_32",
-            "OBJ_35"
+            "OBJ_34",
+            "OBJ_38"
          );
          dependencies = (
          );
@@ -24,24 +24,24 @@
       };
       "NWWebSocket::NWWebSocketPackageTests::ProductTarget" = {
          isa = "PBXAggregateTarget";
-         buildConfigurationList = "OBJ_43";
+         buildConfigurationList = "OBJ_46";
          buildPhases = (
          );
          dependencies = (
-            "OBJ_46"
+            "OBJ_49"
          );
          name = "NWWebSocketPackageTests";
          productName = "NWWebSocketPackageTests";
       };
       "NWWebSocket::NWWebSocketTests" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_48";
+         buildConfigurationList = "OBJ_51";
          buildPhases = (
-            "OBJ_51",
-            "OBJ_56"
+            "OBJ_54",
+            "OBJ_59"
          );
          dependencies = (
-            "OBJ_58"
+            "OBJ_61"
          );
          name = "NWWebSocketTests";
          productName = "NWWebSocketTests";
@@ -55,9 +55,9 @@
       };
       "NWWebSocket::SwiftPMPackageDescription" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_37";
+         buildConfigurationList = "OBJ_40";
          buildPhases = (
-            "OBJ_40"
+            "OBJ_43"
          );
          dependencies = (
          );
@@ -79,7 +79,7 @@
             "en"
          );
          mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_21";
+         productRefGroup = "OBJ_23";
          projectDirPath = ".";
          targets = (
             "NWWebSocket::NWWebSocket",
@@ -89,17 +89,17 @@
          );
       };
       "OBJ_10" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_11"
-         );
-         name = "Client";
-         path = "Client";
+         isa = "PBXFileReference";
+         path = "NWConnection+Extension.swift";
          sourceTree = "<group>";
       };
       "OBJ_11" = {
-         isa = "PBXFileReference";
-         path = "NWWebSocket.swift";
+         isa = "PBXGroup";
+         children = (
+            "OBJ_12"
+         );
+         name = "Model";
+         path = "Model";
          sourceTree = "<group>";
       };
       "OBJ_12" = {
@@ -107,13 +107,13 @@
          children = (
             "OBJ_13"
          );
-         name = "Protocol";
-         path = "Protocol";
+         name = "Client";
+         path = "Client";
          sourceTree = "<group>";
       };
       "OBJ_13" = {
          isa = "PBXFileReference";
-         path = "WebSocketConnection.swift";
+         path = "NWWebSocket.swift";
          sourceTree = "<group>";
       };
       "OBJ_14" = {
@@ -121,44 +121,48 @@
          children = (
             "OBJ_15"
          );
+         name = "Protocol";
+         path = "Protocol";
+         sourceTree = "<group>";
+      };
+      "OBJ_15" = {
+         isa = "PBXFileReference";
+         path = "WebSocketConnection.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_16" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_17"
+         );
          name = "Tests";
          path = "";
          sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_15" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_16",
-            "OBJ_17",
-            "OBJ_20"
-         );
-         name = "NWWebSocketTests";
-         path = "Tests/NWWebSocketTests";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_16" = {
-         isa = "PBXFileReference";
-         path = "NWWebSocketTests.swift";
-         sourceTree = "<group>";
       };
       "OBJ_17" = {
          isa = "PBXGroup";
          children = (
             "OBJ_18",
-            "OBJ_19"
+            "OBJ_19",
+            "OBJ_22"
          );
-         name = "Server";
-         path = "Server";
-         sourceTree = "<group>";
+         name = "NWWebSocketTests";
+         path = "Tests/NWWebSocketTests";
+         sourceTree = "SOURCE_ROOT";
       };
       "OBJ_18" = {
          isa = "PBXFileReference";
-         path = "NWServerConnection.swift";
+         path = "NWWebSocketTests.swift";
          sourceTree = "<group>";
       };
       "OBJ_19" = {
-         isa = "PBXFileReference";
-         path = "NWWebSocketServer.swift";
+         isa = "PBXGroup";
+         children = (
+            "OBJ_20",
+            "OBJ_21"
+         );
+         name = "Server";
+         path = "Server";
          sourceTree = "<group>";
       };
       "OBJ_2" = {
@@ -172,10 +176,20 @@
       };
       "OBJ_20" = {
          isa = "PBXFileReference";
-         path = "XCTestManifests.swift";
+         path = "NWServerConnection.swift";
          sourceTree = "<group>";
       };
       "OBJ_21" = {
+         isa = "PBXFileReference";
+         path = "NWWebSocketServer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_22" = {
+         isa = "PBXFileReference";
+         path = "XCTestManifests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_23" = {
          isa = "PBXGroup";
          children = (
             "NWWebSocket::NWWebSocket::Product",
@@ -185,34 +199,25 @@
          path = "";
          sourceTree = "BUILT_PRODUCTS_DIR";
       };
-      "OBJ_24" = {
+      "OBJ_26" = {
          isa = "PBXFileReference";
          path = "NWWebSocket.podspec";
          sourceTree = "<group>";
       };
-      "OBJ_25" = {
+      "OBJ_27" = {
          isa = "PBXFileReference";
          path = "LICENSE.md";
          sourceTree = "<group>";
       };
-      "OBJ_26" = {
+      "OBJ_28" = {
          isa = "PBXFileReference";
          path = "CHANGELOG.md";
          sourceTree = "<group>";
       };
-      "OBJ_27" = {
+      "OBJ_29" = {
          isa = "PBXFileReference";
          path = "README.md";
          sourceTree = "<group>";
-      };
-      "OBJ_29" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_30",
-            "OBJ_31"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
       };
       "OBJ_3" = {
          isa = "XCBuildConfiguration";
@@ -256,152 +261,121 @@
          };
          name = "Debug";
       };
-      "OBJ_30" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NWWebSocket.xcodeproj/NWWebSocket_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "13.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.15";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "NWWebSocket";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "NWWebSocket";
-            TVOS_DEPLOYMENT_TARGET = "13.0";
-            WATCHOS_DEPLOYMENT_TARGET = "6.0";
-         };
-         name = "Debug";
-      };
       "OBJ_31" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NWWebSocket.xcodeproj/NWWebSocket_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "13.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.15";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "NWWebSocket";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "NWWebSocket";
-            TVOS_DEPLOYMENT_TARGET = "13.0";
-            WATCHOS_DEPLOYMENT_TARGET = "6.0";
-         };
-         name = "Release";
-      };
-      "OBJ_32" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_33",
-            "OBJ_34"
-         );
-      };
-      "OBJ_33" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_11";
-      };
-      "OBJ_34" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_13";
-      };
-      "OBJ_35" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_37" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_38",
-            "OBJ_39"
+            "OBJ_32",
+            "OBJ_33"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
       };
-      "OBJ_38" = {
+      "OBJ_32" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
-            LD = "/usr/bin/true";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NWWebSocket.xcodeproj/NWWebSocket_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "13.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.15";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
             OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5.1.0"
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "NWWebSocket";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
             );
             SWIFT_VERSION = "5.0";
+            TARGET_NAME = "NWWebSocket";
+            TVOS_DEPLOYMENT_TARGET = "13.0";
+            WATCHOS_DEPLOYMENT_TARGET = "6.0";
          };
          name = "Debug";
       };
-      "OBJ_39" = {
+      "OBJ_33" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
-            LD = "/usr/bin/true";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NWWebSocket.xcodeproj/NWWebSocket_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "13.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.15";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
             OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5.1.0"
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "NWWebSocket";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
             );
             SWIFT_VERSION = "5.0";
+            TARGET_NAME = "NWWebSocket";
+            TVOS_DEPLOYMENT_TARGET = "13.0";
+            WATCHOS_DEPLOYMENT_TARGET = "6.0";
          };
          name = "Release";
+      };
+      "OBJ_34" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_35",
+            "OBJ_36",
+            "OBJ_37"
+         );
+      };
+      "OBJ_35" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_10";
+      };
+      "OBJ_36" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_13";
+      };
+      "OBJ_37" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_15";
+      };
+      "OBJ_38" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
       };
       "OBJ_4" = {
          isa = "XCBuildConfiguration";
@@ -442,104 +416,149 @@
          name = "Release";
       };
       "OBJ_40" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_41"
-         );
-      };
-      "OBJ_41" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_6";
-      };
-      "OBJ_43" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_44",
-            "OBJ_45"
+            "OBJ_41",
+            "OBJ_42"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
       };
+      "OBJ_41" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk",
+               "-package-description-version",
+               "5.1.0"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_42" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk",
+               "-package-description-version",
+               "5.1.0"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Release";
+      };
+      "OBJ_43" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_44"
+         );
+      };
       "OBJ_44" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_6";
+      };
+      "OBJ_46" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_47",
+            "OBJ_48"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_47" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
          };
          name = "Debug";
       };
-      "OBJ_45" = {
+      "OBJ_48" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
          };
          name = "Release";
       };
-      "OBJ_46" = {
+      "OBJ_49" = {
          isa = "PBXTargetDependency";
          target = "NWWebSocket::NWWebSocketTests";
-      };
-      "OBJ_48" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_49",
-            "OBJ_50"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_49" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NWWebSocket.xcodeproj/NWWebSocketTests_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "14.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.15";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "NWWebSocketTests";
-            TVOS_DEPLOYMENT_TARGET = "13.0";
-            WATCHOS_DEPLOYMENT_TARGET = "6.0";
-         };
-         name = "Debug";
       };
       "OBJ_5" = {
          isa = "PBXGroup";
          children = (
             "OBJ_6",
             "OBJ_7",
-            "OBJ_14",
-            "OBJ_21",
-            "OBJ_24",
-            "OBJ_25",
+            "OBJ_16",
+            "OBJ_23",
             "OBJ_26",
-            "OBJ_27"
+            "OBJ_27",
+            "OBJ_28",
+            "OBJ_29"
          );
          path = "";
          sourceTree = "<group>";
       };
-      "OBJ_50" = {
+      "OBJ_51" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_52",
+            "OBJ_53"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_52" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NWWebSocket.xcodeproj/NWWebSocketTests_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "14.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.15";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "NWWebSocketTests";
+            TVOS_DEPLOYMENT_TARGET = "13.0";
+            WATCHOS_DEPLOYMENT_TARGET = "6.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_53" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
             CLANG_ENABLE_MODULES = "YES";
@@ -578,50 +597,50 @@
          };
          name = "Release";
       };
-      "OBJ_51" = {
+      "OBJ_54" = {
          isa = "PBXSourcesBuildPhase";
          files = (
-            "OBJ_52",
-            "OBJ_53",
-            "OBJ_54",
-            "OBJ_55"
+            "OBJ_55",
+            "OBJ_56",
+            "OBJ_57",
+            "OBJ_58"
          );
-      };
-      "OBJ_52" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_16";
-      };
-      "OBJ_53" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_18";
-      };
-      "OBJ_54" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_19";
       };
       "OBJ_55" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
+         fileRef = "OBJ_18";
       };
       "OBJ_56" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_57"
-         );
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_20";
       };
       "OBJ_57" = {
          isa = "PBXBuildFile";
-         fileRef = "NWWebSocket::NWWebSocket::Product";
+         fileRef = "OBJ_21";
       };
       "OBJ_58" = {
-         isa = "PBXTargetDependency";
-         target = "NWWebSocket::NWWebSocket";
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_22";
+      };
+      "OBJ_59" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_60"
+         );
       };
       "OBJ_6" = {
          isa = "PBXFileReference";
          explicitFileType = "sourcecode.swift";
          path = "Package.swift";
          sourceTree = "<group>";
+      };
+      "OBJ_60" = {
+         isa = "PBXBuildFile";
+         fileRef = "NWWebSocket::NWWebSocket::Product";
+      };
+      "OBJ_61" = {
+         isa = "PBXTargetDependency";
+         target = "NWWebSocket::NWWebSocket";
       };
       "OBJ_7" = {
          isa = "PBXGroup";
@@ -636,7 +655,8 @@
          isa = "PBXGroup";
          children = (
             "OBJ_9",
-            "OBJ_12"
+            "OBJ_11",
+            "OBJ_14"
          );
          name = "NWWebSocket";
          path = "Sources/NWWebSocket";
@@ -647,8 +667,8 @@
          children = (
             "OBJ_10"
          );
-         name = "Model";
-         path = "Model";
+         name = "Extension";
+         path = "Extension";
          sourceTree = "<group>";
       };
    };

--- a/Sources/NWWebSocket/Extension/NWConnection+Extension.swift
+++ b/Sources/NWWebSocket/Extension/NWConnection+Extension.swift
@@ -1,0 +1,15 @@
+import Network
+
+fileprivate var _intentionalDisconnection: Bool = false
+
+internal extension NWConnection {
+
+    var intentionalDisconnection: Bool {
+        get {
+            return _intentionalDisconnection
+        }
+        set {
+            _intentionalDisconnection = newValue
+        }
+    }
+}

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -162,6 +162,8 @@ open class NWWebSocket: WebSocketConnection {
 
     // MARK: - Private methods
 
+    // MARK: Connection state changes
+
     /// The handler for managing changes to the `connection.state` via the `stateUpdateHandler` on a `NWConnection`.
     /// - Parameter state: The new `NWConnection.State`
     private func stateDidChange(to state: NWConnection.State) {
@@ -305,6 +307,8 @@ open class NWWebSocket: WebSocketConnection {
                             }
                          }))
     }
+
+    // MARK: Connection cleanup
 
     /// Tear down the `connection`.
     ///

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -188,13 +188,12 @@ open class NWWebSocket: WebSocketConnection {
     /// - Parameter isAvailable: `true` if a better network path is available.
     private func betterPath(isAvailable: Bool) {
         if isAvailable {
-            migrateConnection { result in
-                switch result {
-                case .success():
-                    print("CONNECTION MIGRATION SUCCEEDED")
-                case .failure(let error):
-                    print("CONNECTION MIGRATION FAILED: \(error.debugDescription)")
+            migrateConnection { [weak self] result in
+                guard let self = self else {
+                    return
                 }
+
+                self.delegate?.webSocketDidAttemptBetterPathMigration(result: result)
             }
         }
     }
@@ -202,7 +201,7 @@ open class NWWebSocket: WebSocketConnection {
     /// The handler for informing the `delegate` if the network connection viability has changed.
     /// - Parameter isViable: `true` if the network connection is viable.
     private func viabilityDidChange(isViable: Bool) {
-        print("CONNECTION VIABLE?: \(isViable)")
+        delegate?.webSocketViabilityDidChange(connection: self, isViable: isViable)
     }
 
     /// Attempts to migrate the active `connection` to a new one.

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -61,11 +61,13 @@ open class NWWebSocket: WebSocketConnection {
     open func connect() {
         if connection == nil {
             connection = NWConnection(to: endpoint, using: parameters)
+            connection?.stateUpdateHandler = stateDidChange(to:)
+            connection?.betterPathUpdateHandler = betterPath(isAvailable:)
+            connection?.viabilityUpdateHandler = viabilityDidChange(isViable:)
+            listen()
+            connection?.start(queue: connectionQueue)
         }
-        intentionalDisconnect = false
-        connection?.stateUpdateHandler = stateDidChange(to:)
         listen()
-        connection?.start(queue: connectionQueue)
     }
 
     open func send(string: String) {

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -172,11 +172,11 @@ open class NWWebSocket: WebSocketConnection {
         case .waiting(let error):
             reportErrorOrDisconnection(error)
         case .failed(let error):
-            stopConnection(error: error)
+            tearDownConnection(error: error)
         case .setup, .preparing:
             break
         case .cancelled:
-            stopConnection(error: nil)
+            tearDownConnection(error: nil)
         @unknown default:
             fatalError()
         }
@@ -312,7 +312,7 @@ open class NWWebSocket: WebSocketConnection {
     /// This method should only be called in response to a `connection` which has entered either
     /// a `cancelled` or `failed` state within the `stateUpdateHandler` closure.
     /// - Parameter error: error description
-    private func stopConnection(error: NWError?) {
+    private func tearDownConnection(error: NWError?) {
         if let error = error, shouldReportNWError(error) {
             delegate?.webSocketDidReceiveError(connection: self, error: error)
         }

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -21,7 +21,6 @@ open class NWWebSocket: WebSocketConnection {
     private let parameters: NWParameters
     private let connectionQueue: DispatchQueue
     private var pingTimer: Timer?
-    private var intentionalDisconnect: Bool = false
 
     // MARK: - Initialization
 
@@ -141,7 +140,7 @@ open class NWWebSocket: WebSocketConnection {
     }
 
     open func disconnect(closeCode: NWProtocolWebSocket.CloseCode = .protocolCode(.normalClosure)) {
-        intentionalDisconnect = true
+        connection?.intentionalDisconnection = true
 
         // Call `cancel()` directly for a `normalClosure`
         // (Otherwise send the custom closeCode as a message).
@@ -271,7 +270,7 @@ open class NWWebSocket: WebSocketConnection {
     private func shouldReportNWError(_ error: NWError) -> Bool {
         if case let .posix(code) = error,
            code == .ENOTCONN || code == .ECANCELED,
-           intentionalDisconnect {
+           (connection?.intentionalDisconnection ?? false) {
             return false
         } else {
             return true

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -137,7 +137,7 @@ open class NWWebSocket: WebSocketConnection {
         let context = NWConnection.ContentContext(identifier: "pingContext",
                                                   metadata: [metadata])
 
-        send(data: Data(), context: context)
+        send(data: "ping".data(using: .utf8), context: context)
     }
 
     open func disconnect(closeCode: NWProtocolWebSocket.CloseCode = .protocolCode(.normalClosure)) {

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -217,7 +217,7 @@ open class NWWebSocket: WebSocketConnection {
 
             switch state {
             case .ready:
-                self.connection = nil
+                self.connection?.forceCancel()
                 migratedConnection.stateUpdateHandler = self.stateDidChange(to:)
                 migratedConnection.betterPathUpdateHandler = self.betterPath(isAvailable:)
                 migratedConnection.viabilityUpdateHandler = self.viabilityDidChange(isViable:)

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -217,7 +217,6 @@ open class NWWebSocket: WebSocketConnection {
 
             switch state {
             case .ready:
-                self.connection?.cancel()
                 migratedConnection.stateUpdateHandler = self.stateDidChange(to:)
                 migratedConnection.betterPathUpdateHandler = self.betterPath(isAvailable:)
                 migratedConnection.viabilityUpdateHandler = self.viabilityDidChange(isViable:)

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -217,6 +217,7 @@ open class NWWebSocket: WebSocketConnection {
 
             switch state {
             case .ready:
+                self.connection = nil
                 migratedConnection.stateUpdateHandler = self.stateDidChange(to:)
                 migratedConnection.betterPathUpdateHandler = self.betterPath(isAvailable:)
                 migratedConnection.viabilityUpdateHandler = self.viabilityDidChange(isViable:)

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -127,11 +127,11 @@ open class NWWebSocket: WebSocketConnection {
                 return
             }
 
-            self.delegate?.webSocketDidReceivePong(connection: self)
-
             if let error = error {
                 self.delegate?.webSocketDidReceiveError(connection: self,
                                                         error: error)
+            } else {
+                self.delegate?.webSocketDidReceivePong(connection: self)
             }
         }
         let context = NWConnection.ContentContext(identifier: "pingContext",

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -217,7 +217,7 @@ open class NWWebSocket: WebSocketConnection {
 
             switch state {
             case .ready:
-                self.connection?.forceCancel()
+                self.connection = nil
                 migratedConnection.stateUpdateHandler = self.stateDidChange(to:)
                 migratedConnection.betterPathUpdateHandler = self.betterPath(isAvailable:)
                 migratedConnection.viabilityUpdateHandler = self.viabilityDidChange(isViable:)

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -220,6 +220,7 @@ open class NWWebSocket: WebSocketConnection {
 
             switch state {
             case .ready:
+                self.connection?.cancel()
                 migratedConnection.stateUpdateHandler = self.stateDidChange(to:)
                 migratedConnection.betterPathUpdateHandler = self.betterPath(isAvailable:)
                 migratedConnection.viabilityUpdateHandler = self.viabilityDidChange(isViable:)

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -208,9 +208,9 @@ open class NWWebSocket: WebSocketConnection {
     /// Attempts to migrate the active `connection` to a new one.
     ///
     /// Migrating can be useful if the active `connection` detects that a better network path has become available.
-    /// - Parameter completionHandler: Returns a `Result` indicating if the migration was successful or a `NWError` if
-    /// the migration failed for some reason.
-    private func migrateConnection(completionHandler: @escaping (Result<Void, NWError>) -> Void) {
+    /// - Parameter completionHandler: Returns a `Result`with the new connection if the migration was successful
+    /// or a `NWError` if the migration failed for some reason.
+    private func migrateConnection(completionHandler: @escaping (Result<WebSocketConnection, NWError>) -> Void) {
 
         let migratedConnection = NWConnection(to: endpoint, using: parameters)
         migratedConnection.stateUpdateHandler = { [weak self] state in
@@ -226,7 +226,7 @@ open class NWWebSocket: WebSocketConnection {
                 migratedConnection.viabilityUpdateHandler = self.viabilityDidChange(isViable:)
                 self.connection = migratedConnection
                 self.listen()
-                completionHandler(.success(()))
+                completionHandler(.success(self))
             case .waiting(let error):
                 completionHandler(.failure(error))
             case .failed(let error):

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -174,9 +174,7 @@ open class NWWebSocket: WebSocketConnection {
             delegate?.webSocketDidReceiveError(connection: self, error: error)
         case .failed(let error):
             stopConnection(error: error)
-        case .setup:
-            break
-        case .preparing:
+        case .setup, .preparing:
             break
         case .cancelled:
             stopConnection(error: nil)

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -67,7 +67,6 @@ open class NWWebSocket: WebSocketConnection {
             listen()
             connection?.start(queue: connectionQueue)
         }
-        listen()
     }
 
     open func send(string: String) {

--- a/Sources/NWWebSocket/Protocol/WebSocketConnection.swift
+++ b/Sources/NWWebSocket/Protocol/WebSocketConnection.swift
@@ -46,6 +46,24 @@ public protocol WebSocketConnectionDelegate: AnyObject {
                                 closeCode: NWProtocolWebSocket.CloseCode,
                                 reason: Data?)
 
+    /// Tells the delegate that the WebSocket connection viability has changed.
+    ///
+    /// An example scenario of when this method would be called is a Wi-Fi connection being lost due to a device
+    /// moving out of signal range, and then the method would be called again once the device moved back in range.
+    /// - Parameters:
+    ///   - connection: The `WebSocketConnection` whose viability has changed.
+    ///   - isViable: A `Bool` indicating if the connection is viable or not.
+    func webSocketViabilityDidChange(connection: WebSocketConnection,
+                                     isViable: Bool)
+
+    /// Tells the delegate that the WebSocket has attempted a migration based on a better network path becoming available.
+    ///
+    /// An example of when this method would be called is if a device is using a cellular connection, and a Wi-Fi connection
+    /// becomes available. This method will also be called if a device loses a Wi-Fi connection, and a cellular connection is available.
+    /// - Parameter result: A `Result` containing the `WebSocketConnection` if the migration was successful, or a
+    /// `NWError` if the migration failed for some reason.
+    func webSocketDidAttemptBetterPathMigration(result: Result<WebSocketConnection, NWError>)
+
     /// Tells the delegate that the WebSocket received an error.
     ///
     /// An error received by a WebSocket is not necessarily fatal.

--- a/Tests/NWWebSocketTests/NWWebSocketTests.swift
+++ b/Tests/NWWebSocketTests/NWWebSocketTests.swift
@@ -135,6 +135,16 @@ extension NWWebSocketTests: WebSocketConnectionDelegate {
         Self.disconnectExpectation.fulfill()
     }
 
+    func webSocketViabilityDidChange(connection: WebSocketConnection, isViable: Bool) {
+        if isViable == false {
+            XCTFail("WebSocket should not become unviable during testing.")
+        }
+    }
+
+    func webSocketDidAttemptBetterPathMigration(result: Result<WebSocketConnection, NWError>) {
+        XCTFail("WebSocket should not attempt to migrate to a better path during testing.")
+    }
+
     func webSocketDidReceiveError(connection: WebSocketConnection, error: NWError) {
         Self.errorExpectation?.fulfill()
     }

--- a/Tests/NWWebSocketTests/Server/NWServerConnection.swift
+++ b/Tests/NWWebSocketTests/Server/NWServerConnection.swift
@@ -140,7 +140,7 @@ internal class NWServerConnection {
     }
 
     private func connectionDidReceiveError(_ error: NWError) {
-        print("connection did receive error: \(error.localizedDescription)")
+        print("connection did receive error: \(error.debugDescription)")
     }
 
     private func stopConnection(error: Error?) {

--- a/Tests/NWWebSocketTests/Server/NWServerConnection.swift
+++ b/Tests/NWWebSocketTests/Server/NWServerConnection.swift
@@ -57,7 +57,7 @@ internal class NWServerConnection {
             //
             break
         case .ping:
-            //
+            pong()
             break
         case .pong:
             //
@@ -117,6 +117,13 @@ internal class NWServerConnection {
                 self.listen()
             }
         }
+    }
+
+    private func pong() {
+        let metaData = NWProtocolWebSocket.Metadata(opcode: .pong)
+        let context = NWConnection.ContentContext(identifier: "pongContext",
+                                                  metadata: [metaData])
+        self.send(data: Data(), context: context)
     }
 
     private func send(data: Data?, context: NWConnection.ContentContext) {

--- a/Tests/NWWebSocketTests/Server/NWWebSocketServer.swift
+++ b/Tests/NWWebSocketTests/Server/NWWebSocketServer.swift
@@ -73,7 +73,7 @@ internal class NWSwiftWebSocketServer {
         case .setup:
             print("Server is setup.")
         case .waiting(let error):
-            print("Server is waiting to start, non-fatal error: \(error.localizedDescription)")
+            print("Server is waiting to start, non-fatal error: \(error.debugDescription)")
         case .ready:
             print("Server ready.")
         case .cancelled:
@@ -98,7 +98,7 @@ internal class NWSwiftWebSocketServer {
         }
         self.connectionsByID.removeAll()
         if let error = error {
-            print("Server failure, error: \(error.localizedDescription)")
+            print("Server failure, error: \(error.debugDescription)")
         } else {
             print("Server stopped normally.")
         }


### PR DESCRIPTION
This PR:

- Adds private method `betterPath(isAvailable:)` for migrating the internal `NWConnection` when a better network path becomes available (e.g. The device is using a cellular connection and a Wi-Fi connection becomes available, or a Wi-Fi connection drops but there is a cellular connection available).
  - Adds `webSocketDidAttemptBetterPathMigration(result:)` for informing the delegate.
- Adds private method `viabilityDidChange(isViable:)` for reporting connection viability changes (e.g. the Wi-Fi connection drops out).
  - Adds `webSocketViabilityDidChange(connection:isViable:)` for informing the delegate.
- Consolidates error reporting into `reportErrorOrDisconnection(_ error:)` method
  - Improves detection of unexpected disconnection events, and informs the delegate accordingly.
- Updates tests. 