### PR TITLE
Prepare for 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/NWWebSocket/compare/0.5.0...HEAD)
+## [Unreleased](https://github.com/pusher/NWWebSocket/compare/0.5.1...HEAD)
+
+## [0.5.1](https://github.com/pusher/NWWebSocket/compare/0.5.0...0.5.1) - 2020-12-15
+
+### Fixed
+
+- Resolved a race condition that could prevent a manual reconnection attempt in certain circumstances. 
 
 ## [0.5.0](https://github.com/pusher/NWWebSocket/compare/0.4.0...0.5.0) - 2020-11-20
 

--- a/NWWebSocket.podspec
+++ b/NWWebSocket.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'NWWebSocket'
-    s.version          = '0.5.0'
+    s.version          = '0.5.1'
     s.summary          = 'A WebSocket client written in Swift, using the Network framework from Apple'
     s.homepage         = 'https://github.com/pusher/NWWebSocket'
     s.license          = 'MIT'


### PR DESCRIPTION
This PR prepares for the 0.5.1 release:

- Updates CHANGELOG.md.
- Updates NWWebSocket.podspec.