### PR TITLE
Prepare for 0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/NWWebSocket/compare/0.5.1...HEAD)
+## [Unreleased](https://github.com/pusher/NWWebSocket/compare/0.5.2...HEAD)
+
+## [0.5.2](https://github.com/pusher/NWWebSocket/compare/0.5.1...0.5.2) - 2021-03-11
+
+### Fixed
+
+- Resolved an issue preventing App Store submission when integrating NWWebSocket using certain dependency managers.
 
 ## [0.5.1](https://github.com/pusher/NWWebSocket/compare/0.5.0...0.5.1) - 2020-12-15
 

--- a/NWWebSocket.podspec
+++ b/NWWebSocket.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'NWWebSocket'
-    s.version          = '0.5.1'
+    s.version          = '0.5.2'
     s.summary          = 'A WebSocket client written in Swift, using the Network framework from Apple'
     s.homepage         = 'https://github.com/pusher/NWWebSocket'
     s.license          = 'MIT'


### PR DESCRIPTION
This PR prepares for the 0.5.2 release:

- Updates CHANGELOG.md.
- Updates NWWebSocket.podspec.