### PR TITLE
Fix dispatch work item retain cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/NWWebSocket/compare/0.5.2...HEAD)
 
+## [0.5.3](https://github.com/pusher/NWWebSocket/compare/0.5.2...0.5.3) - 2023-04-04
+
+### Fixed
+
+- Prevent memory leak when disconnecting and reconnecting.
+
 ## [0.5.2](https://github.com/pusher/NWWebSocket/compare/0.5.1...0.5.2) - 2021-03-11
 
 ### Fixed

--- a/NWWebSocket.podspec
+++ b/NWWebSocket.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'NWWebSocket'
-    s.version          = '0.5.2'
+    s.version          = '0.5.3'
     s.summary          = 'A WebSocket client written in Swift, using the Network framework from Apple'
     s.homepage         = 'https://github.com/pusher/NWWebSocket'
     s.license          = 'MIT'

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -83,9 +83,15 @@ open class NWWebSocket: WebSocketConnection {
     open func connect() {
         if connection == nil {
             connection = NWConnection(to: endpoint, using: parameters)
-            connection?.stateUpdateHandler = stateDidChange(to:)
-            connection?.betterPathUpdateHandler = betterPath(isAvailable:)
-            connection?.viabilityUpdateHandler = viabilityDidChange(isViable:)
+            connection?.stateUpdateHandler = { [weak self] state in
+                self?.stateDidChange(to: state)
+            }
+            connection?.betterPathUpdateHandler = { [weak self] isAvailable in
+                self?.betterPath(isAvailable: isAvailable)
+            }
+            connection?.viabilityUpdateHandler = { [weak self] isViable in
+                self?.viabilityDidChange(isViable: isViable)
+            }
             listen()
             connection?.start(queue: connectionQueue)
         }

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -345,7 +345,8 @@ open class NWWebSocket: WebSocketConnection {
         // Cancel any existing `disconnectionWorkItem` that was set first
         disconnectionWorkItem?.cancel()
 
-        disconnectionWorkItem = DispatchWorkItem {
+        disconnectionWorkItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
             self.delegate?.webSocketDidDisconnect(connection: self,
                                                   closeCode: closeCode,
                                                   reason: reason)


### PR DESCRIPTION
**Problem:**
The dispatch work item created create a strong reference to `self`, which in turn have a `strong` reference on `disconnectionWorkItem`, creating an infinite retain cycle that makes the NWWebSocket an immortal object

This is a major memory leak for apps that try _arbitrarily_ disconnect from the websocket (i.e.: a logout) and then reconnect later (i.e.: a login)

This cause multiple socket to be alive, and taking up a sizeable amount of system resources

Bug was introduced by commit 45eafe24fb1c9be1ab09f9c7fa97c30ba7aab09c

**Solution**
Add the `[weak self] in` clause in the dispatch work item declaration, and add a `guard let self else { return }` for the case where `self` is truly deallocated.

The solution has been tested, and resolved the memory leak with no adverse side-effect

