### PR TITLE
Fix ENODATA and unrecognised POSIX errors not treated as disconnections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/NWWebSocket/compare/0.5.9...HEAD)
+## [Unreleased](https://github.com/pusher/NWWebSocket/compare/0.5.10...HEAD)
+
+## [0.5.10](https://github.com/pusher/NWWebSocket/compare/0.5.9...0.5.10) - 2026-03-03
+
+### Fixed
+
+- Treat any POSIX error as a disconnection to handle ENODATA (96) and other unrecognised codes that leave the connection in a zombie state
 
 ## [0.5.9](https://github.com/pusher/NWWebSocket/compare/0.5.8...0.5.9) - 2025-12-05
 

--- a/NWWebSocket.podspec
+++ b/NWWebSocket.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'NWWebSocket'
-    s.version          = '0.5.9'
+    s.version          = '0.5.10'
     s.summary          = 'A WebSocket client written in Swift, using the Network framework from Apple'
     s.homepage         = 'https://github.com/pusher/NWWebSocket'
     s.license          = 'MIT'

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '14.0'
 use_frameworks!
 
-pod 'NWWebSocket', '~> 0.5.9'
+pod 'NWWebSocket', '~> 0.5.10'
 ```
 
 Then, run the following command:
@@ -90,7 +90,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pusher/NWWebSocket.git",
-                 .upToNextMajor(from: "0.5.9")),
+                 .upToNextMajor(from: "0.5.10")),
     ],
     targets: [
         .target(

--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -526,6 +526,8 @@ open class NWWebSocket: WebSocketConnection {
         // Only schedule disconnection if we haven't already scheduled one
         if isDisconnectionNWError(error) && disconnectionWorkItem == nil {
             let reasonData = "The websocket disconnected unexpectedly".data(using: .utf8)
+            // Cancel the zombie connection to ensure reconnect creates a fresh NWConnection
+            connection?.cancel()
             scheduleDisconnectionReporting(closeCode: .protocolCode(.goingAway),
                                            reason: reasonData)
         }
@@ -558,6 +560,9 @@ open class NWWebSocket: WebSocketConnection {
             || code == .ECANCELED
             || code == .ENETDOWN
             || code == .ECONNABORTED {
+            return true
+        } else if case .posix(_) = error {
+            // Catch-all for other POSIX errors (e.g. ENODATA) that also indicate a dead connection
             return true
         } else {
             return false


### PR DESCRIPTION
Fixes #62

When a WebSocket connection receives POSIX error 96 (ENODATA: "No message available on STREAM"), the previous `isDisconnectionNWError` check did not recognise it, leaving the `NWConnection` in a zombie `.ready` state. Subsequent reconnect attempts would reuse the dead connection and immediately fail with the same error, causing an unrecoverable reconnection loop.

### Changes
- Add a catch-all `else if case .posix(_)` branch to `isDisconnectionNWError` to handle ENODATA and any other unrecognised POSIX errors that also indicate a dead connection
- Call `connection?.cancel()` before scheduling disconnection reporting to ensure the zombie `NWConnection` is torn down so a fresh one is created on reconnect
- Bump version to 0.5.10

Thanks to @joelmbell for the suggestion in #63.